### PR TITLE
Run sync in pre-command when source is s3.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,3 +20,4 @@ steps:
       - shellcheck#v1.1.2:
           files:
             - hooks/**
+            - lib/**

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A [Buildkite plugin] that syncs files to the AWS Simple Storage Service (S3).
 
 ## Example
 
+Sync files after the command with s3 (`post-command` hook)
+
 ```yml
 steps:
   - label: "Generate files and push to S3"
@@ -15,6 +17,18 @@ steps:
       - envato/aws-s3-sync#v0.2.0:
           source: local-directory/
           destination: s3://example-bucket/directory/
+```
+
+When the source is s3, it will sync files before the command (`pre-command` hook)
+
+```yml
+steps:
+  - label: "Pull files from S3 and execute task"
+    command: bin/command-that-uses-files
+    plugins:
+      - envato/aws-s3-sync#v0.2.0:
+          source: s3://example-bucket/directory/
+          destination: local-directory/
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Buildkite plugin] that syncs files to the AWS Simple Storage Service (S3).
 
 ## Example
 
-Sync files after the command with s3 (`post-command` hook)
+Sync files with s3 after the command (`post-command` hook)
 
 ```yml
 steps:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ steps:
           destination: local-directory/
 ```
 
+Syncing s3 files source with a s3 files destination. This is run after the main command in a [`post-command` job hook](https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks).
+
+````yml
+steps:
+  - label: "Copy between buckets"
+    plugins:
+      - envato/no-command#v0.1.0: ~
+      - envato/aws-s3-sync#v0.3.0:
+          source: s3://example-bucket/directory/
+          destination: s3://other-bucket/directory/
+
 ## Configuration
 
 ### `source`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
   - label: "Generate files and push to S3"
     command: bin/command-that-generates-files
     plugins:
-      - envato/aws-s3-sync#v0.2.0:
+      - envato/aws-s3-sync#v0.3.0:
           source: local-directory/
           destination: s3://example-bucket/directory/
 ```
@@ -26,7 +26,7 @@ steps:
   - label: "Pull files from S3 and execute task"
     command: bin/command-that-uses-files
     plugins:
-      - envato/aws-s3-sync#v0.2.0:
+      - envato/aws-s3-sync#v0.3.0:
           source: s3://example-bucket/directory/
           destination: local-directory/
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Buildkite plugin] that syncs files to the AWS Simple Storage Service (S3). It
 
 ## Example
 
-Sync local files source with s3 destination, after the `command`.
+Sync local files source with s3 destination. This is run after the main command in a [`post-command` job hook](https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks).
 
 ```yml
 steps:
@@ -19,7 +19,7 @@ steps:
           destination: s3://example-bucket/directory/
 ```
 
-Sync s3 files source with a local path destination, before the `command`.
+Sync s3 files source with a local path destination. This is run before the main command in a [`pre-command` job hook](https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks).
 
 ```yml
 steps:

--- a/README.md
+++ b/README.md
@@ -31,17 +31,6 @@ steps:
           destination: local-directory/
 ```
 
-Syncing s3 files source with a s3 files destination. This is run after the main command in a [`post-command` job hook](https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks).
-
-````yml
-steps:
-  - label: "Copy between buckets"
-    plugins:
-      - envato/no-command#v0.1.0: ~
-      - envato/aws-s3-sync#v0.3.0:
-          source: s3://example-bucket/directory/
-          destination: s3://other-bucket/directory/
-
 ## Configuration
 
 ### `source`

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![Build status](https://badge.buildkite.com/39a2058c81ac115411ffaa5f902b15c5c6afd425ce2194c371.svg?branch=main)
 [![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE)
 
-A [Buildkite plugin] that syncs files to the AWS Simple Storage Service (S3).
+A [Buildkite plugin] that syncs files to the AWS Simple Storage Service (S3). It automatically detects when the local path is the source or destination, then syncs after or before the step `command` respectively.
 
 ## Example
 
-Sync files with s3 after the command (`post-command` hook)
+Sync local files source with s3 destination, after the `command`.
 
 ```yml
 steps:
@@ -19,7 +19,7 @@ steps:
           destination: s3://example-bucket/directory/
 ```
 
-When the source is s3, it will sync files before the command (`pre-command` hook)
+Sync s3 files source with a local path destination, before the `command`.
 
 ```yml
 steps:
@@ -35,11 +35,11 @@ steps:
 
 ### `source`
 
-The source directory containing the files to sync to S3.
+The source location containing the local path or the s3 uri.
 
 ### `destination`
 
-The S3 URI describing where to sync the files to.
+The destination location containing the local path or the s3 uri.
 
 ### `delete`
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -13,7 +13,5 @@ fi
 
 if [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE != s3://* ]] ;then
   aws_s3_sync "$BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE" "$BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION"
-else
-  echo '~~~ Skipping S3 sync during post-command because source is s3'
 fi
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,7 +6,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 source "$DIR/../lib/shared.bash"
 
-if [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE == s3://* ]] ;then
+if [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE == s3://* ]] && [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION != s3://* ]] ;then
   aws_s3_sync "$BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE" "$BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION"
 else
   echo '~~~ Skipping S3 sync during pre-command because source is a local directory'

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -8,7 +8,5 @@ source "$DIR/../lib/shared.bash"
 
 if [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE == s3://* ]] && [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION != s3://* ]] ;then
   aws_s3_sync "$BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE" "$BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION"
-else
-  echo '~~~ Skipping S3 sync during pre-command because source is a local directory'
 fi
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,14 +6,9 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 source "$DIR/../lib/shared.bash"
 
-if [[ ${BUILDKITE_COMMAND_EXIT_STATUS:-0} != '0' ]]; then
-  echo '~~~ Skipping S3 sync because the command failed'
-  exit 0
-fi
-
-if [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE != s3://* ]] ;then
+if [[ $BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE == s3://* ]] ;then
   aws_s3_sync "$BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE" "$BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION"
 else
-  echo '~~~ Skipping S3 sync during post-command because source is s3'
+  echo '~~~ Skipping S3 sync during pre-command because source is a local directory'
 fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -14,6 +14,9 @@ function aws_s3_sync() {
     params+=(--no-follow-symlinks)
   fi
 
+  params+=("$source")
+  params+=("$destination")
+
   echo "~~~ :s3: Syncing $source to $destination"
-  aws s3 sync "${params[@]}" "$source" "$destination" 
+  aws s3 sync "${params[@]}"
 }

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 function aws_s3_sync() {
-  local params=()
   local source=$1
   local destination=$2
+
+  params=()
 
   if [[ "${BUILDKITE_PLUGIN_AWS_S3_SYNC_DELETE:-false}" == "true" ]]; then
     params+=(--delete)

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function aws_s3_sync() {
+  local params=()
+  local source=$1
+  local destination=$2
+
+  if [[ "${BUILDKITE_PLUGIN_AWS_S3_SYNC_DELETE:-false}" == "true" ]]; then
+    params+=(--delete)
+  fi
+
+  if [[ "${BUILDKITE_PLUGIN_AWS_S3_SYNC_FOLLOW_SYMLINKS:-true}" == "false" ]]; then
+    params+=(--no-follow-symlinks)
+  fi
+
+  echo "~~~ :s3: Syncing $source to $destination"
+  aws s3 sync "${params[@]}" "$source" "$destination" 
+}

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -67,6 +67,5 @@ load '/usr/local/lib/bats/load.bash'
 
   run $PWD/hooks/post-command
 
-  assert_output --partial "Skipping S3 sync during post-command"
   assert_success
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -56,5 +56,17 @@ load '/usr/local/lib/bats/load.bash'
 
   run $PWD/hooks/post-command
 
+  assert_output --partial "Skipping S3 sync because the command failed"
+  assert_success
+}
+
+@test "Skips post command when source is s3" {
+  export BUILDKITE_COMMAND_EXIT_STATUS=0
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
+
+  run $PWD/hooks/post-command
+
+  assert_output --partial "Skipping S3 sync during post-command"
   assert_success
 }

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -55,3 +55,13 @@ load '/usr/local/lib/bats/load.bash'
   assert_output --partial "Skipping S3 sync during pre-command"
   assert_success
 }
+
+@test "Skips pre command when source and destination are both s3" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
+
+  run $PWD/hooks/pre-command
+
+  assert_output --partial "Skipping S3 sync during pre-command"
+  assert_success
+}

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -52,7 +52,6 @@ load '/usr/local/lib/bats/load.bash'
 
   run $PWD/hooks/pre-command
 
-  assert_output --partial "Skipping S3 sync during pre-command"
   assert_success
 }
 
@@ -62,6 +61,5 @@ load '/usr/local/lib/bats/load.bash'
 
   run $PWD/hooks/pre-command
 
-  assert_output --partial "Skipping S3 sync during pre-command"
   assert_success
 }

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment the following to get more detail on failures of stubs
+# export AWS_STUB_DEBUG=/dev/tty
+
+@test "Syncs files from the source directory to the destination S3 bucket" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
+
+  stub aws "s3 sync s3://source destination/ : echo s3 sync"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "s3 sync"
+  unstub aws
+}
+
+@test "Syncs and deletes files" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DELETE=true
+
+  stub aws "s3 sync --delete s3://source destination/ : echo s3 sync --delete"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "s3 sync --delete"
+  unstub aws
+}
+
+@test "Doesn't follow symlinks" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_FOLLOW_SYMLINKS=false
+
+  stub aws "s3 sync --no-follow-symlinks s3://source destination/ : echo s3 sync --no-follow-symlinks"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "s3 sync --no-follow-symlinks"
+  unstub aws
+}
+
+@test "Skips pre command when source is local" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
+
+  run $PWD/hooks/pre-command
+
+  assert_output --partial "Skipping S3 sync during pre-command"
+  assert_success
+}


### PR DESCRIPTION
Updates to automatically detect when the local path is the source or destination, then syncs after or before the step `command` respectively.

## Example

Sync local files source with s3 destination, after the `command`.

```yml
steps:
  - label: "Generate files and push to S3"
    command: bin/command-that-generates-files
    plugins:
      - envato/aws-s3-sync#v0.3.0:
          source: local-directory/
          destination: s3://example-bucket/directory/
```

Sync s3 files source with a local path destination, before the `command`.

```yml
steps:
  - label: "Pull files from S3 and execute task"
    command: bin/command-that-uses-files
    plugins:
      - envato/aws-s3-sync#v0.3.0:
          source: s3://example-bucket/directory/
          destination: local-directory/
```