### PR TITLE
Add cache control option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Files that exist in the destination but not in the source are deleted during syn
 
 Defaults to `true`
 
-Symbolic links are followed only when uploading to S3 from the local filesystem.
+Symbolic links are followed only when uploading to S3 from the local filesystem. 
+
+### `cache-control`
+
+Defaults to `null`
+
+Specify the cache control metadata value for all syncable objects 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
   - label: "Generate files and push to S3"
     command: bin/command-that-generates-files
     plugins:
-      - envato/aws-s3-sync#v0.3.0:
+      - envato/aws-s3-sync#v0.4.0:
           source: local-directory/
           destination: s3://example-bucket/directory/
 ```
@@ -26,7 +26,7 @@ steps:
   - label: "Pull files from S3 and execute task"
     command: bin/command-that-uses-files
     plugins:
-      - envato/aws-s3-sync#v0.3.0:
+      - envato/aws-s3-sync#v0.4.0:
           source: s3://example-bucket/directory/
           destination: local-directory/
 ```

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -15,7 +15,7 @@ function aws_s3_sync() {
   fi
 
   if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL:-}" ]]; then
-    params+=("--cache-control ${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL}")
+    params+=("--cache-control=${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL/\ /}")
   fi
 
   params+=("$source")

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -14,7 +14,7 @@ function aws_s3_sync() {
     params+=(--no-follow-symlinks)
   fi
 
-  if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL:-}" ]]; then
+  if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL:-}" ]] && [[ $destination == s3://* ]]; then
     params+=("--cache-control=${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL/\ /}")
   fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -14,6 +14,10 @@ function aws_s3_sync() {
     params+=(--no-follow-symlinks)
   fi
 
+  if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL:-}" ]]; then
+    params+=("--cache-control ${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL}")
+  fi
+
   params+=("$source")
   params+=("$destination")
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -13,6 +13,8 @@ configuration:
       type: boolean
     follow-symlinks:
       type: boolean
+    cache-control:
+      type: string
   required:
     - source
     - destination

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -39,12 +39,12 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL="public, max-age=315360000"
 
-  stub aws "s3 sync --cache-control public, max-age=315360000 source/ s3://destination : echo s3 sync --cache-control public, max-age=315360000"
+  stub aws "s3 sync --cache-control=public,max-age=315360000 source/ s3://destination : echo s3 sync --cache-control=public,max-age=315360000"
 
   run $PWD/hooks/post-command
 
   assert_success
-  assert_output --partial "s3 sync --cache-control public, max-age=315360000"
+  assert_output --partial "s3 sync --cache-control=public,max-age=315360000"
   unstub aws
 }
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -34,6 +34,20 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
+@test "Syncs with cache control metadata" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL="public, max-age=315360000"
+
+  stub aws "s3 sync --cache-control public, max-age=315360000 source/ s3://destination : echo s3 sync --cache-control public, max-age=315360000"
+
+  run $PWD/hooks/post-command
+
+  assert_success
+  assert_output --partial "s3 sync --cache-control public, max-age=315360000"
+  unstub aws
+}
+
 @test "Doesn't follow symlinks" {
   export BUILDKITE_COMMAND_EXIT_STATUS=0
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -46,17 +46,17 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Syncs with cache control metadata" {
+@test "Ignores cache control option" {
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL="public,max-age=315360000"
 
-  stub aws "s3 sync --cache-control=public,max-age=315360000 s3://source destination/ : echo s3 sync --cache-control=public,max-age=315360000"
+  stub aws "s3 sync s3://source destination/ : echo s3 sync"
 
   run $PWD/hooks/pre-command
 
   assert_success
-  assert_output --partial "s3 sync --cache-control=public,max-age=315360000"
+  assert_output --partial "s3 sync"
   unstub aws
 }
 

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -49,14 +49,14 @@ load '/usr/local/lib/bats/load.bash'
 @test "Syncs with cache control metadata" {
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
-  export BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL="public, max-age=315360000"
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL="public,max-age=315360000"
 
-  stub aws "s3 sync --cache-control public, max-age=315360000 s3://source destination/ : echo s3 sync --cache-control public, max-age=315360000"
+  stub aws "s3 sync --cache-control=public,max-age=315360000 s3://source destination/ : echo s3 sync --cache-control=public,max-age=315360000"
 
   run $PWD/hooks/pre-command
 
   assert_success
-  assert_output --partial "s3 sync --cache-control public, max-age=315360000"
+  assert_output --partial "s3 sync --cache-control=public,max-age=315360000"
   unstub aws
 }
 

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -46,6 +46,20 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
+@test "Syncs with cache control metadata" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL="public, max-age=315360000"
+
+  stub aws "s3 sync --cache-control public, max-age=315360000 s3://source destination/ : echo s3 sync --cache-control public, max-age=315360000"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "s3 sync --cache-control public, max-age=315360000"
+  unstub aws
+}
+
 @test "Skips pre command when source is local" {
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination


### PR DESCRIPTION
## Context

When using aws s3 sync, it is common to pass a cache control flag. 

## Changes

* Add new `cache-control` option on buildkite plugin. Values passed look like "public, max-age=315360000"
* Trim whitespace from cache control option when passing it to aws cli. This will reduce issues with array splatting

## Considerations

* Yes, there are a lot more options available to S3 that would be great to have present on this plugin, but given time constraints imposed on our team, I'm opting for one step forward in the right direction.