### PR TITLE
Add endpoint url option to customise the s3 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Specify the cache control metadata value for all syncable objects
 
 Defaults to `null`
 
-Specify the s3 endpoint URL to use.
+Optionally specify an s3 endpoint URL to override the default. This option can be used to integrate with services that provide a s3 compatible api like CloudFlare R2.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Defaults to `null`
 
 Specify the cache control metadata value for all syncable objects 
 
-### `endpoint`
+### `endpoint-url`
 
 Defaults to `null`
 
-Specify the s3 endpoint to use.
+Specify the s3 endpoint URL to use.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
   - label: "Generate files and push to S3"
     command: bin/command-that-generates-files
     plugins:
-      - envato/aws-s3-sync#v0.4.0:
+      - envato/aws-s3-sync#v0.5.0:
           source: local-directory/
           destination: s3://example-bucket/directory/
 ```
@@ -26,7 +26,7 @@ steps:
   - label: "Pull files from S3 and execute task"
     command: bin/command-that-uses-files
     plugins:
-      - envato/aws-s3-sync#v0.4.0:
+      - envato/aws-s3-sync#v0.5.0:
           source: s3://example-bucket/directory/
           destination: local-directory/
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Defaults to `null`
 
 Specify the cache control metadata value for all syncable objects 
 
+### `endpoint`
+
+Defaults to `null`
+
+Specify the s3 endpoint to use.
+
 ## Development
 
 To run the tests:

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -18,7 +18,7 @@ function aws_s3_sync() {
     params+=("--cache-control=${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL/\ /}")
   fi
 
-  if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL:-}" ]] && [[ $destination == s3://* ]]; then
+  if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL:-}" ]]; then
     params+=("--endpoint-url=${BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL/\ /}")
   fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -18,6 +18,10 @@ function aws_s3_sync() {
     params+=("--cache-control=${BUILDKITE_PLUGIN_AWS_S3_SYNC_CACHE_CONTROL/\ /}")
   fi
 
+  if [[ -n "${BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL:-}" ]] && [[ $destination == s3://* ]]; then
+    params+=("--endpoint-url=${BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL/\ /}")
+  fi
+
   params+=("$source")
   params+=("$destination")
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,7 +15,7 @@ configuration:
       type: boolean
     cache-control:
       type: string
-    endpoint:
+    endpoint-url:
       type: string
   required:
     - source

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,8 @@ configuration:
       type: boolean
     cache-control:
       type: string
+    endpoint:
+      type: string
   required:
     - source
     - destination

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -63,7 +63,7 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Doesn't follow symlinks" {
+@test "Uses endpoint URL" {
   export BUILDKITE_COMMAND_EXIT_STATUS=0
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -63,6 +63,21 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
+@test "Doesn't follow symlinks" {
+  export BUILDKITE_COMMAND_EXIT_STATUS=0
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=envato-test-bucket.s3-website-us-east-1.amazonaws.com
+
+  stub aws "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com s3://source destination/ : echo s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+
+  run $PWD/hooks/post-command
+
+  assert_success
+  assert_output --partial "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  unstub aws
+}
+
 @test "Doesn't attempt to sync files if the step command fails" {
   export BUILDKITE_COMMAND_EXIT_STATUS=1
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -69,7 +69,7 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=envato-test-bucket.s3-website-us-east-1.amazonaws.com
 
-  stub aws "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com s3://source destination/ : echo s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  stub aws "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com source/ s3://destination : echo s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
 
   run $PWD/hooks/post-command
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -67,14 +67,14 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_COMMAND_EXIT_STATUS=0
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=source/
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=s3://destination
-  export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=envato-test-bucket.s3-website-us-east-1.amazonaws.com
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=https://myaccountid.r2.cloudflarestorage.com
 
-  stub aws "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com source/ s3://destination : echo s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  stub aws "s3 sync --endpoint-url=https://myaccountid.r2.cloudflarestorage.com source/ s3://destination : echo s3 sync --endpoint-url=https://myaccountid.r2.cloudflarestorage.com"
 
   run $PWD/hooks/post-command
 
   assert_success
-  assert_output --partial "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  assert_output --partial "s3 sync --endpoint-url=https://myaccountid.r2.cloudflarestorage.com"
   unstub aws
 }
 

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -46,6 +46,20 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
+@test "Uses endpoint URL" {
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=envato-test-bucket.s3-website-us-east-1.amazonaws.com
+
+  stub aws "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com s3://source destination/ : echo s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  unstub aws
+}
+
 @test "Ignores cache control option" {
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -49,14 +49,14 @@ load '/usr/local/lib/bats/load.bash'
 @test "Uses endpoint URL" {
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_SOURCE=s3://source
   export BUILDKITE_PLUGIN_AWS_S3_SYNC_DESTINATION=destination/
-  export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=envato-test-bucket.s3-website-us-east-1.amazonaws.com
+  export BUILDKITE_PLUGIN_AWS_S3_SYNC_ENDPOINT_URL=https://myaccountid.r2.cloudflarestorage.com
 
-  stub aws "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com s3://source destination/ : echo s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  stub aws "s3 sync --endpoint-url=https://myaccountid.r2.cloudflarestorage.com s3://source destination/ : echo s3 sync --endpoint-url=https://myaccountid.r2.cloudflarestorage.com"
 
   run $PWD/hooks/pre-command
 
   assert_success
-  assert_output --partial "s3 sync --endpoint-url=envato-test-bucket.s3-website-us-east-1.amazonaws.com"
+  assert_output --partial "s3 sync --endpoint-url=https://myaccountid.r2.cloudflarestorage.com"
   unstub aws
 }
 


### PR DESCRIPTION
This PR adds the ability to customise the s3 endpoint url by setting the `endpoint-url` option.

This allows us to use this plugin for services like CloudFlare R2 which is API compatible with s3 and just requires customising the endpoint.